### PR TITLE
update readme comment regarding core applescript

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 # Div — simple Alfred windows manager
 
-This is simple Alfred workflow to help you manage opened windows. It is simple (50 lines of applescript) but powerful tool. It allows you to create your own layouts, custom sizes and custom proportion.
+This is simple Alfred workflow to help you manage opened windows. It is simple (see the short applescript in div.scpt) but powerful tool. It allows you to create your own layouts, custom sizes and custom proportion.
 
 ## Requirements
 


### PR DESCRIPTION
div.scpt is (while still short!) now well longer than 50 lines

indicate the filename int the comment too

really been enjoying Div. I see no need for paid window managers like Divvy or Sizeup anymore. thank you for making this!